### PR TITLE
Add groups management

### DIFF
--- a/example.rb
+++ b/example.rb
@@ -51,6 +51,28 @@ begin
   resp = PeRbac::get_permissions
   puts resp.body
 
+  # Manage groups
+  require 'pe_rbac/group'
+  require 'json'
+
+  # Get all groups
+  puts JSON.pretty_generate PeRbac::Group.get_groups
+
+  # Create group
+  resp = PeRbac::Group.ensure_group('test-group', 2)
+  puts resp.code
+
+  # Get one group
+  test_group = PeRbac::Group.get_group(PeRbac::Group.get_group_id('test-group'))
+
+  # Update role in group
+  resp = PeRbac::Group.ensure_group('test-group', [1,2])
+  puts resp.code
+
+  # Remove group
+  resp = PeRbac::Group.delete_group('test-group')
+  puts resp.code
+
 rescue Exception => e
   puts e.message
   puts e.backtrace

--- a/lib/pe_rbac/group.rb
+++ b/lib/pe_rbac/group.rb
@@ -1,0 +1,89 @@
+#
+# Copyright 2017 Declarative Systems PTY LTD
+# Copyright 2016 Puppet Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+require 'json'
+require 'pe_rbac/core'
+require 'pe_rbac/action'
+
+module PeRbac
+  module Group
+    def self.get_groups
+      JSON.parse(PeRbac::Core::request(:get, '/groups').body)
+    end
+
+    # get the user id for a login or false if missing
+    # eg 'admin' => '42bf351c-f9ec-40af-84ad-e976fec7f4bd'
+    def self.get_group_id(login)
+      groups = get_groups
+      id = false
+      i = 0
+      while !id and i < groups.length do
+        if groups[i]['login'] == login
+          id = groups[i]['id']
+        end
+        i += 1
+      end
+      id
+    end
+
+    def self.get_group(id)
+      resp = PeRbac::Core::request(:get, "/groups/#{id}")
+      resp ? JSON.parse(resp.body) : false
+    end
+
+    def self.ensure_group(login, role_ids)
+      if get_group_id(login)
+        # existing group
+        update_group(login, role_ids)
+      else
+        # new group
+        create_group(login, role_ids)
+      end
+
+    end
+
+    def self.create_group(login, role_ids=[])
+      # completely different to what the PE console sends... :/
+      # Elegantly convert role_ids to an array if it isn't one already
+      group={
+        "login"         => login,
+        "role_ids"      => Array(role_ids),
+      }
+
+      PeRbac::Core::request(:post, '/groups', group) ? true : false
+    end
+
+    def self.update_group(login, role_ids=[])
+      group = get_group(get_group_id(login))
+      status = false
+      if group
+        group['login'] = login ? login : group['login']
+        group['role_ids'] = role_ids ? Array(role_ids) : group['role_ids']
+
+        status = PeRbac::Core::request(:put, "/groups/#{group['id']}", group) ? true : false
+      end
+      status
+    end
+
+    def self.delete_group(login)
+      group = get_group(get_group_id(login))
+      status = false
+      if group
+        PeRbac::Core::request(:delete, "/groups/#{group['id']}") ? true : false
+      end
+      status
+    end
+  end
+end

--- a/lib/pe_rbac/version.rb
+++ b/lib/pe_rbac/version.rb
@@ -15,5 +15,5 @@
 # limitations under the License.
 
 module PeRbac
-  VERSION = "1.1.1"
+  VERSION = "1.2.0"
 end

--- a/spec/fake_rbac_service.rb
+++ b/spec/fake_rbac_service.rb
@@ -116,6 +116,36 @@ module FakeRbacService
 
       res.to_json
     end
+
+    # All groups
+    get '/rbac-api/v1/groups' do
+      read_json('get', 'groups')
+    end
+
+    # a specific user
+    get '/rbac-api/v1/groups/:id' do
+      found = nil
+      JSON.parse(read_json('get', 'groups')).each { |j|
+        if j['id'] == params[:id]
+          found = j
+        end
+      }
+      if found
+        payload = found.to_json
+      else
+        status 404
+      end
+    end
+
+    # create a user
+    post '/rbac-api/v1/groups' do
+      status 201
+    end
+
+    # update a user
+    put '/rbac-api/v1/groups/:id' do
+      status 200
+    end
   end
 
   module WEBrick

--- a/spec/fixtures/json/get/groups.json
+++ b/spec/fixtures/json/get/groups.json
@@ -1,0 +1,28 @@
+[
+  {
+    "id": "df374820-9a78-46e3-85ee-726793923f23",
+    "login": "test_group",
+    "display_name": "test_group",
+    "role_ids": [
+      2,
+      1
+    ],
+    "user_ids": [],
+    "is_group": true,
+    "is_remote": true,
+    "is_superuser": false
+  },
+  {
+    "id": "9cfb0f32-df90-4900-8212-ed2b31a4340c",
+    "login": "admins",
+    "display_name": "admins",
+    "role_ids": [
+      2,
+      1
+    ],
+    "user_ids": [],
+    "is_group": true,
+    "is_remote": true,
+    "is_superuser": false
+  }
+]

--- a/spec/pe_rbac/group_spec.rb
+++ b/spec/pe_rbac/group_spec.rb
@@ -1,0 +1,90 @@
+require 'pe_rbac/group'
+require "fake_rbac_service"
+require "spec_helper"
+
+# before do
+# #   FakeRbacService::WEBrick.run!
+#   PeRbac::Core::set_ssldir("./spec/fixtures/ssl")
+#   PeRbac::Core::set_fqdn("localhost")
+# end
+
+describe PeRbac::Group do
+  it "returns full list of groups" do
+    groups = PeRbac::Group::get_groups
+
+    # check we got a response the same size as the one in our json file
+    expect(groups).not_to be nil
+    expect(groups.size).to be 2
+  end
+
+  it "returns a specific group" do
+    group = PeRbac::Group::get_group('df374820-9a78-46e3-85ee-726793923f23')
+
+    # check we got a response the same size as the one in our json file
+    expect(group).not_to be nil
+    expect(group['login']).to eq'test_group'
+  end
+
+  it "returns false looking up non-existent group by id" do
+    group = PeRbac::Group::get_group('xxxxxxxx')
+
+    # check we got a response the same size as the one in our json file
+    expect(group).to be false
+  end
+
+  it "returns the correct ID for given group" do
+    uid = PeRbac::Group::get_group_id('admins')
+
+    expect(uid).to eq '9cfb0f32-df90-4900-8212-ed2b31a4340c'
+  end
+
+  it "returns false for non existent group" do
+    uid = PeRbac::Group::get_group_id('not_here')
+
+    expect(uid).to eq false
+  end
+
+  # create_group
+  it "creates a normal group correctly" do
+    result = PeRbac::Group::create_group(
+      'login',
+      4
+    )
+    expect(result).to be true
+  end
+
+  # update_group
+  it "updates an existing group correctly" do
+    result = PeRbac::Group::update_group(
+      'admins',
+      5,
+    )
+    expect(result).to be true
+  end
+
+  it "returns false attempting to update non-existent group" do
+    result = PeRbac::Group::update_group(
+      'not_here',
+      5,
+    )
+    expect(result).to be false
+  end
+
+  # ensure_group
+  it "ensures groups are in desired state correctly" do
+    # existing group - should indicate success
+    result = PeRbac::Group::ensure_group(
+      'admins',
+      4
+    )
+    expect(result).to be true
+
+    # new group - should indicate success
+    result = PeRbac::Group::ensure_group(
+      'not_here',
+      4
+    )
+    expect(result).to be true
+  end
+
+end


### PR DESCRIPTION
- [x] Code updated
- [x] Tests updated
- [x] Examples updated

```
$ ruby -e 'require "pe_rbac"; require "pe_rbac/group"; puts PeRbac::Group.create_group("test_group")'
true

$ ruby -e 'require "pe_rbac"; require "pe_rbac/group"; puts PeRbac::Group.get_group(PeRbac::Group.get_group_id("test_group"))'
{"id"=>"980c6872-a03a-4a07-836c-1435686123e5", "login"=>"test_group", "display_name"=>"test_groups", "role_ids"=>[], "user_ids"=>[], "is_group"=>true, "is_remote"=>true, "is_superuser"=>false}

$  ruby -e 'require "pe_rbac"; require "pe_rbac/group"; puts PeRbac::Group.ensure_group("test_group", 1)'
true
$ ruby -e 'require "pe_rbac"; require "pe_rbac/group"; puts PeRbac::Group.get_group(PeRbac::Group.get_group_id("test_group"))'
{"id"=>"980c6872-a03a-4a07-836c-1435686123e5", "login"=>"test_group", "display_name"=>"test_group", "role_ids"=>[1], "user_ids"=>[], "is_group"=>true, "is_remote"=>true, "is_superuser"=>false}

$ ruby -e 'require "pe_rbac"; require "pe_rbac/group"; puts PeRbac::Group.ensure_group("test_group", [1,2])'
true
$ ruby -e 'require "pe_rbac"; require "pe_rbac/group"; puts PeRbac::Group.get_group(PeRbac::Group.get_group_id("test_group"))'
{"id"=>"980c6872-a03a-4a07-836c-1435686123e5", "login"=>"test_group", "display_name"=>"test_group", "role_ids"=>[1, 2], "user_ids"=>[], "is_group"=>true, "is_remote"=>true, "is_superuser"=>false}
```

